### PR TITLE
docs: split modules to ease review / fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         run: cd src && python3 -m unittest discover -v
       - name: Document
         run: |
-          sphinx-apidoc -o docs/ -f -a src/
+          sphinx-apidoc -o docs/ -f -a -e src/ --doc-project "Python SDK for Arcaflow"
           make -C docs html
       - name: Run example plugin
         run: ./example_plugin.py -f example.yaml

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If your plugin defines more than one step, you may need to pass the `--step` par
 4. Run `pip install -r requirements.txt`
 5. Run `pip install sphinx`
 6. Run `pip install sphinx-rtd-theme`
-7. Run `sphinx-apidoc -o docs/ -f -a src/`
+7. Run `sphinx-apidoc -o docs/ -f -a -e src/ --doc-project "Python SDK for Arcaflow"`
 8. Run `make -C docs html`
 
 

--- a/docs/arcaflow_plugin_sdk.annotations.rst
+++ b/docs/arcaflow_plugin_sdk.annotations.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.annotations module
+========================================
+
+.. automodule:: arcaflow_plugin_sdk.annotations
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.http.rst
+++ b/docs/arcaflow_plugin_sdk.http.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.http module
+=================================
+
+.. automodule:: arcaflow_plugin_sdk.http
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.jsonschema.rst
+++ b/docs/arcaflow_plugin_sdk.jsonschema.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.jsonschema module
+=======================================
+
+.. automodule:: arcaflow_plugin_sdk.jsonschema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.plugin.rst
+++ b/docs/arcaflow_plugin_sdk.plugin.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.plugin module
+===================================
+
+.. automodule:: arcaflow_plugin_sdk.plugin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.rst
+++ b/docs/arcaflow_plugin_sdk.rst
@@ -4,85 +4,19 @@ arcaflow\_plugin\_sdk package
 Submodules
 ----------
 
-arcaflow\_plugin\_sdk.annotations module
-----------------------------------------
+.. toctree::
+   :maxdepth: 4
 
-.. automodule:: arcaflow_plugin_sdk.annotations
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.http module
----------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.http
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.jsonschema module
----------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.jsonschema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.plugin module
------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.plugin
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.schema module
------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.schema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.serialization module
-------------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.serialization
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.test\_jsonschema module
----------------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.test_jsonschema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.test\_plugin module
------------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.test_plugin
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.test\_schema module
------------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.test_schema
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arcaflow\_plugin\_sdk.validation module
----------------------------------------
-
-.. automodule:: arcaflow_plugin_sdk.validation
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   arcaflow_plugin_sdk.annotations
+   arcaflow_plugin_sdk.http
+   arcaflow_plugin_sdk.jsonschema
+   arcaflow_plugin_sdk.plugin
+   arcaflow_plugin_sdk.schema
+   arcaflow_plugin_sdk.serialization
+   arcaflow_plugin_sdk.test_jsonschema
+   arcaflow_plugin_sdk.test_plugin
+   arcaflow_plugin_sdk.test_schema
+   arcaflow_plugin_sdk.validation
 
 Module contents
 ---------------

--- a/docs/arcaflow_plugin_sdk.schema.rst
+++ b/docs/arcaflow_plugin_sdk.schema.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.schema module
+===================================
+
+.. automodule:: arcaflow_plugin_sdk.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.serialization.rst
+++ b/docs/arcaflow_plugin_sdk.serialization.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.serialization module
+==========================================
+
+.. automodule:: arcaflow_plugin_sdk.serialization
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.test_jsonschema.rst
+++ b/docs/arcaflow_plugin_sdk.test_jsonschema.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.test\_jsonschema module
+=============================================
+
+.. automodule:: arcaflow_plugin_sdk.test_jsonschema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.test_plugin.rst
+++ b/docs/arcaflow_plugin_sdk.test_plugin.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.test\_plugin module
+=========================================
+
+.. automodule:: arcaflow_plugin_sdk.test_plugin
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.test_schema.rst
+++ b/docs/arcaflow_plugin_sdk.test_schema.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.test\_schema module
+=========================================
+
+.. automodule:: arcaflow_plugin_sdk.test_schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/arcaflow_plugin_sdk.validation.rst
+++ b/docs/arcaflow_plugin_sdk.validation.rst
@@ -1,0 +1,7 @@
+arcaflow\_plugin\_sdk.validation module
+=======================================
+
+.. automodule:: arcaflow_plugin_sdk.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Welcome to Python SDK for Arcaflow's documentation!
    :maxdepth: 4
    :caption: Contents:
 
-   arcaflow_plugin_sdk
+   modules
 
 
 Indices and tables

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+Python SDK for Arcaflow
+=======================
+
+.. toctree::
+   :maxdepth: 4
+
+   arcaflow_plugin_sdk


### PR DESCRIPTION
## Changes introduced with this PR

Split docs for modules, making it easier to review them.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).