### PR TITLE
automation: add coverage to summary only once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Collect coverage report
         run: |
           python3 -m coverage html
+      - name: Publish coverage report to job summary
+        # publishing only once
+        if: ${{ matrix.python-version == '3.9'}}
+        run: |
           pip install html2text
           html2text --ignore-images --ignore-links -b 0 htmlcov/index.html >> $GITHUB_STEP_SUMMARY
       - name: Update version number


### PR DESCRIPTION
## Changes introduced with this PR

avoid to get 3 coverage reports in job summary.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).