### PR TITLE
Fixed any type output, and added None to list of allowed types

### DIFF
--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5446,7 +5446,7 @@ class _SchemaBuilder:
             path: typing.Tuple[str],
             scope: ScopeType,
     ) -> typing.Union[AbstractType, PropertyType]:
-        if isinstance(t, typing._SpecialForm):
+        if t == typing.Any:
             return cls._resolve_any()
         elif isinstance(t, type):
             return cls._resolve_type(t, type_hints, path, scope)

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -1062,7 +1062,8 @@ ANY_TYPE = typing.Union[
     int,
     float,
     bool,
-    str
+    str,
+    types.NoneType
 ]
 VALUE_TYPE = typing.Annotated[
     typing.Union[
@@ -5194,6 +5195,8 @@ class AnyType(AnySchema, AbstractType):
             return
         elif isinstance(data, bool):
             return
+        elif isinstance(data, types.NoneType):
+            return
         else:
             raise ConstraintException(path, "Unsupported data type for 'any' type: {}".format(data.__class__.__name__))
 
@@ -5443,7 +5446,7 @@ class _SchemaBuilder:
             path: typing.Tuple[str],
             scope: ScopeType,
     ) -> typing.Union[AbstractType, PropertyType]:
-        if t == ANY_TYPE:
+        if isinstance(t, typing._SpecialForm):
             return cls._resolve_any()
         elif isinstance(t, type):
             return cls._resolve_type(t, type_hints, path, scope)

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -1063,7 +1063,7 @@ ANY_TYPE = typing.Union[
     float,
     bool,
     str,
-    types.NoneType
+    type(None)
 ]
 VALUE_TYPE = typing.Annotated[
     typing.Union[
@@ -5195,7 +5195,7 @@ class AnyType(AnySchema, AbstractType):
             return
         elif isinstance(data, bool):
             return
-        elif isinstance(data, types.NoneType):
+        elif isinstance(data, type(None)):
             return
         else:
             raise ConstraintException(path, "Unsupported data type for 'any' type: {}".format(data.__class__.__name__))

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -293,6 +293,37 @@ class MapTest(unittest.TestCase):
             t.validate({"foo": "bar", "baz": "Hello world!"})
 
 
+class AnyTest(unittest.TestCase):
+    def test_unserialize(self):
+        t = schema.AnyType()
+        self.assertEqual(1, t.unserialize(1))
+        self.assertEqual(1.0, t.unserialize(1.0))
+        self.assertEqual(True, t.unserialize(True))
+        self.assertEqual("True", t.unserialize("True"))
+        self.assertEqual(None, t.unserialize(None))
+        self.assertEqual({"a": "b"}, t.unserialize({"a": "b"}))
+        self.assertEqual([1, 1.0, None, "a"], t.unserialize([1, 1.0, None, "a"]))
+        self.assertEqual([{0: ["a"]}], t.unserialize([{0: ["a"]}]))
+
+        class IsAClass():
+            pass
+
+        with self.assertRaises(ConstraintException):
+            t.unserialize(set())
+        with self.assertRaises(ConstraintException):
+            t.unserialize(IsAClass())
+
+    def test_validate(self):
+        t = schema.AnyType()
+        t.validate("Hello world!")
+        t.validate(1)
+        t.validate(1.0)
+        t.validate(True)
+        t.validate({"message": "Hello world!"})
+        t.validate(["Hello world!"])
+        t.validate(None)
+
+
 @dataclass
 class TestClass:
     a: str
@@ -694,6 +725,7 @@ class SerializationTest(unittest.TestCase):
             E: typing.Optional[str] = None
             F: typing.Annotated[typing.Optional[str], schema.min(3)] = None
             G: typing.Optional[str] = dataclasses.field(default="", metadata={"id": "test-field", "name": "G"})
+            I: typing.Any = None
 
         schema.test_object_serialization(
             TestData1(
@@ -810,7 +842,7 @@ class SchemaBuilderTest(unittest.TestCase):
             {},
             "a",
         )
-        resolved_type = schema._SchemaBuilder.resolve(schema.ANY_TYPE, scope)
+        resolved_type = schema._SchemaBuilder.resolve(typing.Any, scope)
         self.assertIsInstance(resolved_type, schema.AnyType)
 
     def test_non_dataclass(self):


### PR DESCRIPTION
Fixes #73 

## Changes introduced with this PR

First, I allow detection of the any type in the switch. It does not interfere with the non-any type checks.
Second, I added NoneType to the list of allowed values, because None values in maps and lists are important in a lot of situations, including my metadata plugin

Lastly, I added more test cases for AnyType.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).