### PR TITLE
Added error message for null work start message

### DIFF
--- a/src/arcaflow_plugin_sdk/atp.py
+++ b/src/arcaflow_plugin_sdk/atp.py
@@ -85,6 +85,9 @@ def run_plugin(
     except SystemExit:
         return 0
     try:
+        if message is None:
+            stderr.write("Work start message is None.")
+            return 1
         if message["id"] is None:
             stderr.write("Work start message is missing the 'id' field.")
             return 1


### PR DESCRIPTION
## Changes introduced with this PR

This is a very simple PR that adds an error check for a failure case that has happened in some plugins. This should just make it a bit easier to debug.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).