### PR TITLE
Fix Required If (Not) Properties

### DIFF
--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5005,8 +5005,14 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
     @staticmethod
     def _validate_not_set(data, object_property: PropertyType, path: typing.Tuple[str]):
         """
-        This function applies required_if and required_if_not constraints on an object_property
-        in data. If a constraint has been broken, then it raises a ConstraintException.
+        Validate required_if and required_if_not constraints on a property in the given
+        data object. If a constraint has been broken, then raise a ConstraintException.
+
+        For a description of the required_if constraint visit
+        [https://arcalot.io/arcaflow/plugins/python/schema/?h=required_if#objecttype].
+
+        For a description of the required_if_not constraint visit
+        [https://arcalot.io/arcaflow/plugins/python/schema/?h=required_if_not#objecttype].
 
         :param data: a dictionary representation of an ObjectType
         :param object_property: a property of an ObjectType

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5008,8 +5008,8 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
             raise ConstraintException(path, "This field is required")
         if object_property.required_if is not None:
             for required_if in object_property.required_if:
-                if (isinstance(data, dict) and required_if in data) or (
-                    hasattr(data, required_if) and getattr(data, required_if) is None
+                if (isinstance(data, dict) and required_if in data and data[required_if] is not None) or (
+                    hasattr(data, required_if) and getattr(data, required_if) is not None
                 ):
                     raise ConstraintException(
                         path,

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5023,7 +5023,7 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
         ):
             none_set = True
             for required_if_not in object_property.required_if_not:
-                if (isinstance(data, dict) and required_if_not in data) or (
+                if (isinstance(data, dict) and required_if_not in data and data[required_if_not] is not None) or (
                     hasattr(data, required_if_not)
                     and getattr(data, required_if_not) is not None
                 ):

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5011,6 +5011,12 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
                 if (isinstance(data, dict) and required_if in data and data[required_if] is not None) or (
                     hasattr(data, required_if) and getattr(data, required_if) is not None
                 ):
+                    # (here, required_if refers to its value)
+                    # if data is a dict, has this required_if as a key, and the
+                    # dict value paired with this required_if key is not None
+                    # or
+                    # if data is an object with attribute required_if, and
+                    # data.required_if is not None
                     raise ConstraintException(
                         path,
                         "This field is required because '{}' is set".format(
@@ -5027,6 +5033,12 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
                     hasattr(data, required_if_not)
                     and getattr(data, required_if_not) is not None
                 ):
+                    # (here, required_if_not refers to its value)
+                    # if data is a dict, has this required_if_not as a key, and the
+                    # dict value paired with this required_if_not key is not None
+                    # or
+                    # if data is an object with attribute required_if_not, and
+                    # data.required_if_not is not None
                     none_set = False
                     break
             if none_set:

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5004,6 +5004,14 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
 
     @staticmethod
     def _validate_not_set(data, object_property: PropertyType, path: typing.Tuple[str]):
+        """
+        This function applies required_if and required_if_not constraints on an object_property
+        in data. If a constraint has been broken, then it raises a ConstraintException.
+
+        :param data: a dictionary representation of an ObjectType
+        :param object_property: a property of an ObjectType
+        :param path: a traversal from data to object_property
+        """
         if object_property.required:
             raise ConstraintException(path, "This field is required")
         if object_property.required_if is not None:

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -753,6 +753,10 @@ class SerializationTest(unittest.TestCase):
         self.assertIsNone(unserialized.A)
         self.assertIsNone(unserialized.B)
 
+        unserialized = s.unserialize({"A": None, "B": None})
+        self.assertIsNone(unserialized.A)
+        self.assertIsNone(unserialized.B)
+
         unserialized = s.unserialize({"A": "Foo"})
         self.assertEqual(unserialized.A, "Foo")
         self.assertIsNone(unserialized.B)

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -689,7 +689,6 @@ class OneOfTest(unittest.TestCase):
         self.assertIsInstance(unserialized_data, OneOfData2)
 
 
-import types
 
 class SerializationTest(unittest.TestCase):
     def test_serialization_cycle(self):
@@ -773,7 +772,6 @@ class SerializationTest(unittest.TestCase):
             s.serialize(TestData1(B="Foo"))
 
     def test_required_if_not(self):
-        # List of other properties that, if not filled, lead to the current property being required.
         @dataclasses.dataclass
         class TestData1:
             A: typing.Optional[str] = None

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -689,6 +689,8 @@ class OneOfTest(unittest.TestCase):
         self.assertIsInstance(unserialized_data, OneOfData2)
 
 
+import types
+
 class SerializationTest(unittest.TestCase):
     def test_serialization_cycle(self):
         @dataclasses.dataclass
@@ -763,6 +765,58 @@ class SerializationTest(unittest.TestCase):
 
         with self.assertRaises(schema.ConstraintException):
             s.unserialize({"B": "Foo"})
+
+        with self.assertRaises(schema.ConstraintException):
+            s.validate(TestData1(B="Foo"))
+
+        with self.assertRaises(schema.ConstraintException):
+            s.serialize(TestData1(B="Foo"))
+
+    def test_required_if_not(self):
+        # List of other properties that, if not filled, lead to the current property being required.
+        @dataclasses.dataclass
+        class TestData1:
+            A: typing.Optional[str] = None
+            B: typing.Annotated[typing.Optional[str], schema.required_if_not("A")] = None
+
+        s = schema.build_object_schema(TestData1)
+
+        with self.assertRaises(schema.ConstraintException):
+            s.unserialize({})
+
+        with self.assertRaises(schema.ConstraintException):
+            s.unserialize({"A": None, "B": None})
+
+        unserialized = s.unserialize({"A": "Foo"})
+        self.assertEqual(unserialized.A, "Foo")
+        self.assertIsNone(unserialized.B)
+
+        unserialized = s.unserialize({"B": "Foo"})
+        self.assertEqual(unserialized.B, "Foo")
+        self.assertIsNone(unserialized.A)
+
+        s.validate(TestData1(B="Foo"))
+        s.serialize(TestData1(B="Foo"))
+
+        @dataclasses.dataclass
+        class TestData2:
+            A: typing.Optional[str] = None
+            B: typing.Optional[str] = None
+            C: typing.Annotated[typing.Optional[str], schema.required_if_not("A"), schema.required_if_not("B")] = None
+
+        s = schema.build_object_schema(TestData2)
+
+        with self.assertRaises(schema.ConstraintException):
+            s.unserialize({"A": None, "B": None, "C": None})
+
+        unserialized = s.unserialize({"C": "Foo"})
+        self.assertIsNone(unserialized.A)
+        self.assertIsNone(unserialized.B)
+        self.assertEqual(unserialized.C, "Foo")
+
+        td2_c = TestData2(C="Foo")
+        s.validate(td2_c)
+        s.serialize(td2_c)
 
     def test_int_optional(self):
         @dataclasses.dataclass


### PR DESCRIPTION
## Changes introduced with this PR

1. Fix bug that throws a `ConstraintException` when a plugin input dataclass attribute with a `required_if` property is not set
2. Fix similar bug for `required_if_not`
3. Add `required_if` test cases to cover unserialization, serialization, and validation
4.  Add `required_if_not` test cases to cover unserialization, serialization, and validation

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).