### PR TITLE
correct reference from name to description

### DIFF
--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -5816,7 +5816,7 @@ class _SchemaBuilder:
                 underlying_type.display.name = meta_name
 
         if hasattr(underlying_type, "__description"):
-            underlying_type.display.name = getattr(underlying_type, "__description")
+            underlying_type.display.description = getattr(underlying_type, "__description")
         elif hasattr(base_type, "__description"):
             underlying_type.display.description = getattr(base_type, "__description")
         if (


### PR DESCRIPTION
## Changes introduced with this PR

Small bug fix resolves #92. A `name` value was errantly being set instead of `description`

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).