### PR TITLE
Fix build artifact uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         run: exit 1
       - name: Install poetry
         run: |
-          python -m pip install poetry==1.4.2
+          python -m pip install poetry==1.4
       - name: Configure poetry
         run: |
           python -m poetry config virtualenvs.in-project true
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: logs
+          name: logs-${{ matrix.python-version }}
           path: "*.log"
       - name: Cache the virtualenv
         uses: actions/cache@v4
@@ -90,7 +90,7 @@ jobs:
       - name: Upload coverage HTML artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-${{ matrix.python-version }}
           path: htmlcov
           if-no-files-found: error
   publish:


### PR DESCRIPTION
## Changes introduced with this PR

[As of `v4`](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) of `actions/upload-artifact`, "it is no longer possible to upload to the same named Artifact multiple times."  However, the current build runs repeatedly, for each of Python 3.9, 3.10, and `pypy3.9`, each of which uploads a number of artifacts, most of which have the same name in each run.  So, on the second run, the attempt to upload the `coverage` HTML artifact now fails, or, at least, it did in #122 (it is possible that the problem is timing-related -- it did not happen in #120 or #119).

This change extends the changes in #120 to the other pushed artifacts, so that they have unique names suffixed with the version of Python used in the run.

This change also relaxes the version of Poetry used from `1.4.2` to any `1.4`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).