### PR TITLE
Dry Out OneOf Test Suite

### DIFF
--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -477,6 +477,16 @@ class OneOfTest(unittest.TestCase):
             },
             "a",
         )
+        self.scope_basic_int = schema.ScopeType(
+            {
+                "a": schema.ObjectType(
+                    OneOfTest.OneOfData1,
+                    {"a": PropertyType(schema.StringType())},
+                ),
+                "b": self.obj_b,
+            },
+            "a",
+        )
         self.scope_embedded = schema.ScopeType(
             {
                 "a": schema.ObjectType(
@@ -526,6 +536,20 @@ class OneOfTest(unittest.TestCase):
         )
         self.assertIsInstance(unserialized_data2, OneOfTest.OneOfData2)
         self.assertEqual(unserialized_data2.b, 42)
+
+        s_type_int = schema.OneOfIntType(
+            {
+                1: schema.RefType("a", self.scope_basic_int),
+                2: schema.RefType("b", self.scope_basic_int),
+            },
+            scope=self.scope_basic_int,
+            discriminator_field_name="_type",
+        )
+        unserialized_data3: OneOfTest.OneOfData1 = s_type_int.unserialize(
+            {"_type": 1, "a": "Hello world!"}
+        )
+        self.assertIsInstance(unserialized_data3, OneOfTest.OneOfData1)
+        self.assertEqual(unserialized_data3.a, "Hello world!")
 
     def test_unserialize_embedded(self):
         s = schema.OneOfStringType(
@@ -584,7 +608,7 @@ class OneOfTest(unittest.TestCase):
         )
         self.assertEqual(
             s.serialize(OneOfTest.OneOfData2(42)),
-            {self.discriminator_field_name: "b", "b": 42}
+            {self.discriminator_field_name: "b", "b": 42},
         )
 
     def test_object(self):
@@ -608,7 +632,8 @@ class OneOfTest(unittest.TestCase):
             discriminator_field_name=self.discriminator_field_name,
         )
         unserialized_data = s.unserialize(
-            {self.discriminator_field_name: "b", "b": 42})
+            {self.discriminator_field_name: "b", "b": 42}
+        )
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfData2)
 
 

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -461,6 +461,12 @@ class OneOfTest(unittest.TestCase):
         type_: str
         a: str
 
+    # When a discriminator is embedded with the data schema of the
+    # OneOfType's constituent types (the types in the union set),
+    # then the constituent type's attribute's identifier must match
+    # the OneOf's discriminator identifier. In this case, the string
+    # "type_" is the discriminator identifier that will be embedded in
+    # OneOfDataEmbedded1.
     discriminator_field_name = "type_"
 
     def setUp(self):
@@ -555,7 +561,8 @@ class OneOfTest(unittest.TestCase):
             {self.discriminator_field_name: "a", "a": "Hello world!"}
         )
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfDataEmbedded1)
-        self.assertEqual(unserialized_data.type_, "a")
+        self.assertEqual(
+            getattr(unserialized_data, self.discriminator_field_name), "a")
         self.assertEqual(unserialized_data.a, "Hello world!")
 
         unserialized_data2: OneOfTest.OneOfData2 = s.unserialize(

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -583,7 +583,8 @@ class OneOfTest(unittest.TestCase):
             {self.discriminator_field_name: "a", "a": "Hello world!"},
         )
         self.assertEqual(
-            s.serialize(OneOfTest.OneOfData2(42)), {self.discriminator_field_name: "b", "b": 42}
+            s.serialize(OneOfTest.OneOfData2(42)),
+            {self.discriminator_field_name: "b", "b": 42}
         )
 
     def test_object(self):
@@ -606,7 +607,8 @@ class OneOfTest(unittest.TestCase):
             scope=scope,
             discriminator_field_name=self.discriminator_field_name,
         )
-        unserialized_data = s.unserialize({self.discriminator_field_name: "b", "b": 42})
+        unserialized_data = s.unserialize(
+            {self.discriminator_field_name: "b", "b": 42})
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfData2)
 
 

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -468,6 +468,7 @@ class OneOfTest(unittest.TestCase):
     # "type_" is the discriminator identifier that will be embedded in
     # OneOfDataEmbedded1.
     discriminator_field_name = "type_"
+    discriminator_default = "_type"
 
     def setUp(self):
         self.obj_b = schema.ObjectType(
@@ -506,7 +507,6 @@ class OneOfTest(unittest.TestCase):
                 "b": schema.RefType("b", self.scope_basic),
             },
             scope=self.scope_basic,
-            discriminator_field_name="_type",
         )
 
         # Incomplete values to unserialize
@@ -517,18 +517,20 @@ class OneOfTest(unittest.TestCase):
 
         # Mismatching key value
         with self.assertRaises(ConstraintException):
-            s_type.unserialize({"_type": "a", 1: "Hello world!"})
+            s_type.unserialize({
+                self.discriminator_default: "a", 1: "Hello world!"})
         # Invalid key value
         with self.assertRaises(ConstraintException):
-            s_type.unserialize({"_type": 1, 1: "Hello world!"})
+            s_type.unserialize({
+                self.discriminator_default: 1, 1: "Hello world!"})
 
         unserialized_data: OneOfTest.OneOfData1 = s_type.unserialize(
-            {"_type": "a", "a": "Hello world!"}
+            {self.discriminator_default: "a", "a": "Hello world!"}
         )
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfData1)
         self.assertEqual(unserialized_data.a, "Hello world!")
         unserialized_data2: OneOfTest.OneOfData2 = s_type.unserialize(
-            {"_type": "b", "b": 42}
+            {self.discriminator_default: "b", "b": 42}
         )
         self.assertIsInstance(unserialized_data2, OneOfTest.OneOfData2)
         self.assertEqual(unserialized_data2.b, 42)
@@ -539,10 +541,9 @@ class OneOfTest(unittest.TestCase):
                 2: schema.RefType("b", self.scope_basic),
             },
             scope=self.scope_basic,
-            discriminator_field_name="_type",
         )
         unserialized_data3: OneOfTest.OneOfData1 = s_type_int.unserialize(
-            {"_type": 1, "a": "Hello world!"}
+            {self.discriminator_default: 1, "a": "Hello world!"}
         )
         self.assertIsInstance(unserialized_data3, OneOfTest.OneOfData1)
         self.assertEqual(unserialized_data3.a, "Hello world!")

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -467,7 +467,7 @@ class OneOfTest(unittest.TestCase):
         self.obj_b: schema.ObjectType = schema.ObjectType(
             OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())}
         )
-        self.scope_basic: schema.ScopeType = schema.ScopeType(
+        self.scope_basic = schema.ScopeType(
             {
                 "a": schema.ObjectType(
                     OneOfTest.OneOfData1,
@@ -477,7 +477,7 @@ class OneOfTest(unittest.TestCase):
             },
             "a",
         )
-        self.scope_embedded: schema.ScopeType = schema.ScopeType(
+        self.scope_embedded = schema.ScopeType(
             {
                 "a": schema.ObjectType(
                     OneOfTest.OneOfDataEmbedded1,

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -463,11 +463,12 @@ class OneOfTest(unittest.TestCase):
 
     def setUp(self):
         self.obj_b: schema.ObjectType = schema.ObjectType(
-                    OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())})
+            OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())})
         self.scope_basic: schema.ScopeType = schema.ScopeType(
             {
                 "a": schema.ObjectType(
-                    OneOfTest.OneOfData1, {"a": PropertyType(schema.StringType())}
+                    OneOfTest.OneOfData1,
+                    {"a": PropertyType(schema.StringType())}
                 ),
                 "b": self.obj_b,
             },

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -458,8 +458,10 @@ class OneOfTest(unittest.TestCase):
 
     @dataclasses.dataclass
     class OneOfDataEmbedded1:
-        type: str
+        type_: str
         a: str
+
+    discriminator_field_name = "type_"
 
     def setUp(self):
         self.obj_b: schema.ObjectType = schema.ObjectType(
@@ -480,7 +482,7 @@ class OneOfTest(unittest.TestCase):
                 "a": schema.ObjectType(
                     OneOfTest.OneOfDataEmbedded1,
                     {
-                        "type": PropertyType(
+                        self.discriminator_field_name: PropertyType(
                             schema.StringType(),
                         ),
                         "a": PropertyType(schema.StringType()),
@@ -489,26 +491,6 @@ class OneOfTest(unittest.TestCase):
                 "b": self.obj_b,
             },
             "a",
-        )
-
-    def test_assignment(self):
-        s_type = schema.OneOfStringType(
-            {
-                "a": schema.RefType("a", self.scope_basic),
-                "b": schema.RefType("b", self.scope_basic),
-            },
-            scope=self.scope_basic,
-            discriminator_field_name="_type",
-        )
-        s_type.discriminator_field_name = "foo"
-        self.assertEqual("foo", s_type.discriminator_field_name)
-        schema.OneOfIntType(
-            {
-                1: schema.RefType(1, self.scope_basic),
-                2: schema.RefType(2, self.scope_basic),
-            },
-            scope=self.scope_basic,
-            discriminator_field_name="_type",
         )
 
     def test_unserialize(self):
@@ -552,18 +534,18 @@ class OneOfTest(unittest.TestCase):
                 "b": schema.RefType("b", self.scope_embedded),
             },
             scope=self.scope_embedded,
-            discriminator_field_name="type",
+            discriminator_field_name=self.discriminator_field_name,
         )
 
         unserialized_data: OneOfTest.OneOfDataEmbedded1 = s.unserialize(
-            {"type": "a", "a": "Hello world!"}
+            {self.discriminator_field_name: "a", "a": "Hello world!"}
         )
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfDataEmbedded1)
-        self.assertEqual(unserialized_data.type, "a")
+        self.assertEqual(unserialized_data.type_, "a")
         self.assertEqual(unserialized_data.a, "Hello world!")
 
         unserialized_data2: OneOfTest.OneOfData2 = s.unserialize(
-            {"type": "b", "b": 42}
+            {self.discriminator_field_name: "b", "b": 42}
         )
         self.assertIsInstance(unserialized_data2, OneOfTest.OneOfData2)
         self.assertEqual(unserialized_data2.b, 42)
@@ -575,7 +557,7 @@ class OneOfTest(unittest.TestCase):
                 "b": schema.RefType("b", self.scope_embedded),
             },
             scope=self.scope_embedded,
-            discriminator_field_name="type",
+            discriminator_field_name=self.discriminator_field_name,
         )
 
         with self.assertRaises(ConstraintException):
@@ -594,14 +576,14 @@ class OneOfTest(unittest.TestCase):
                 "b": schema.RefType("b", self.scope_embedded),
             },
             scope=self.scope_embedded,
-            discriminator_field_name="type",
+            discriminator_field_name=self.discriminator_field_name,
         )
         self.assertEqual(
             s.serialize(OneOfTest.OneOfDataEmbedded1("a", "Hello world!")),
-            {"type": "a", "a": "Hello world!"},
+            {self.discriminator_field_name: "a", "a": "Hello world!"},
         )
         self.assertEqual(
-            s.serialize(OneOfTest.OneOfData2(42)), {"type": "b", "b": 42}
+            s.serialize(OneOfTest.OneOfData2(42)), {self.discriminator_field_name: "b", "b": 42}
         )
 
     def test_object(self):
@@ -611,7 +593,7 @@ class OneOfTest(unittest.TestCase):
                 "a": schema.ObjectType(
                     OneOfTest.OneOfDataEmbedded1,
                     {
-                        "type": PropertyType(
+                        self.discriminator_field_name: PropertyType(
                             schema.StringType(),
                         ),
                         "a": PropertyType(schema.StringType()),
@@ -622,9 +604,9 @@ class OneOfTest(unittest.TestCase):
                 ),
             },
             scope=scope,
-            discriminator_field_name="type",
+            discriminator_field_name=self.discriminator_field_name,
         )
-        unserialized_data = s.unserialize({"type": "b", "b": 42})
+        unserialized_data = s.unserialize({self.discriminator_field_name: "b", "b": 42})
         self.assertIsInstance(unserialized_data, OneOfTest.OneOfData2)
 
 

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -542,7 +542,6 @@ class OneOfTest(unittest.TestCase):
             s_type.unserialize({
                 self.discriminator_default: 1, "b": "Hello world!"})
 
-
         unserialized_data: OneOfTest.OneOfData1 = s_type.unserialize(
             {self.discriminator_default: "a", "a": "Hello world!"}
         )

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -517,7 +517,7 @@ class OneOfTest(unittest.TestCase):
         with self.assertRaises(ConstraintException):
             s_type.unserialize({"_type": 1, 1: "Hello world!"})
 
-        unserialized_data: OneOfData1 = s_type.unserialize(
+        unserialized_data: self.OneOfData1 = s_type.unserialize(
             {"_type": "a", "a": "Hello world!"}
         )
         self.assertIsInstance(unserialized_data, self.OneOfData1)

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -461,6 +461,9 @@ class OneOfTest(unittest.TestCase):
         type_: str
         a: str
 
+    # default discriminator field name
+    discriminator_default = "_type"
+
     # When a discriminator is embedded with the data schema of the
     # OneOfType's constituent types (the types in the union set),
     # then the constituent type's attribute's identifier must match
@@ -468,7 +471,6 @@ class OneOfTest(unittest.TestCase):
     # "type_" is the discriminator identifier that will be embedded in
     # OneOfDataEmbedded1.
     discriminator_field_name = "type_"
-    discriminator_default = "_type"
 
     def setUp(self):
         self.obj_b = schema.ObjectType(

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -448,65 +448,61 @@ class ObjectTest(unittest.TestCase):
 
 
 class OneOfTest(unittest.TestCase):
-    def test_assignment(self):
-        @dataclasses.dataclass
-        class OneOfData1:
-            a: str
+    @dataclasses.dataclass
+    class OneOfData1:
+        a: str
 
-        @dataclasses.dataclass
-        class OneOfData2:
-            b: int
+    @dataclasses.dataclass
+    class OneOfData2:
+        b: int
 
-        scope = schema.ScopeType(
+    def setUp(self):
+        self.scope_basic: schema.ScopeType = schema.ScopeType(
             {
                 "a": schema.ObjectType(
-                    OneOfData1, {"a": PropertyType(schema.StringType())}
+                    self.OneOfData1, {"a": PropertyType(schema.StringType())}
                 ),
                 "b": schema.ObjectType(
-                    OneOfData2, {"b": PropertyType(schema.IntType())}
+                    self.OneOfData2, {"b": PropertyType(schema.IntType())}
                 ),
             },
             "a",
         )
+
+    def test_assignment(self):
         s_type = schema.OneOfStringType(
-            {"a": schema.RefType("a", scope), "b": schema.RefType("b", scope)},
-            scope,
-            "_type",
+            {"a": schema.RefType("a", self.scope_basic), "b": schema.RefType("b", self.scope_basic)},
+            scope=self.scope_basic,
+            discriminator_field_name="_type",
         )
         s_type.discriminator_field_name = "foo"
         self.assertEqual("foo", s_type.discriminator_field_name)
 
         schema.OneOfIntType(
-            {1: schema.RefType(1, scope), 2: schema.RefType(2, scope)},
-            scope,
-            "_type",
+            {1: schema.RefType(1, self.scope_basic), 2: schema.RefType(2, self.scope_basic)},
+            scope=self.scope_basic,
+            discriminator_field_name="_type",
         )
 
     def test_unserialize(self):
-        @dataclasses.dataclass
-        class OneOfData1:
-            a: str
+        # @dataclasses.dataclass
+        # class OneOfData1:
+        #     a: str
+        #
+        # @dataclasses.dataclass
+        # class OneOfData2:
+        #     b: int
 
-        @dataclasses.dataclass
-        class OneOfData2:
-            b: int
-
-        scope = schema.ScopeType(
-            {
-                "a": schema.ObjectType(
-                    OneOfData1, {"a": PropertyType(schema.StringType())}
-                ),
-                "b": schema.ObjectType(
-                    OneOfData2, {"b": PropertyType(schema.IntType())}
-                ),
-            },
-            "a",
-        )
         s_type = schema.OneOfStringType(
-            {"a": schema.RefType("a", scope), "b": schema.RefType("b", scope)},
-            scope,
-            "_type",
+            {"a": schema.RefType("a", self.scope_basic), "b": schema.RefType("b", self.scope_basic)},
+            scope=self.scope_basic,
+            discriminator_field_name="_type",
         )
+        # s_type = schema.OneOfStringType(
+        #     {"a": schema.RefType("a", scope), "b": schema.RefType("b", scope)},
+        #     scope,
+        #     "_type",
+        # )
 
         # Incomplete values to unserialize
         with self.assertRaises(ConstraintException):
@@ -524,13 +520,13 @@ class OneOfTest(unittest.TestCase):
         unserialized_data: OneOfData1 = s_type.unserialize(
             {"_type": "a", "a": "Hello world!"}
         )
-        self.assertIsInstance(unserialized_data, OneOfData1)
+        self.assertIsInstance(unserialized_data, self.OneOfData1)
         self.assertEqual(unserialized_data.a, "Hello world!")
 
         unserialized_data2: OneOfData2 = s_type.unserialize(
             {"_type": "b", "b": 42}
         )
-        self.assertIsInstance(unserialized_data2, OneOfData2)
+        self.assertIsInstance(unserialized_data2, self.OneOfData2)
         self.assertEqual(unserialized_data2.b, 42)
 
     def test_unserialize_embedded(self):

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -477,16 +477,6 @@ class OneOfTest(unittest.TestCase):
             },
             "a",
         )
-        self.scope_basic_int = schema.ScopeType(
-            {
-                "a": schema.ObjectType(
-                    OneOfTest.OneOfData1,
-                    {"a": PropertyType(schema.StringType())},
-                ),
-                "b": self.obj_b,
-            },
-            "a",
-        )
         self.scope_embedded = schema.ScopeType(
             {
                 "a": schema.ObjectType(
@@ -539,10 +529,10 @@ class OneOfTest(unittest.TestCase):
 
         s_type_int = schema.OneOfIntType(
             {
-                1: schema.RefType("a", self.scope_basic_int),
-                2: schema.RefType("b", self.scope_basic_int),
+                1: schema.RefType("a", self.scope_basic),
+                2: schema.RefType("b", self.scope_basic),
             },
-            scope=self.scope_basic_int,
+            scope=self.scope_basic,
             discriminator_field_name="_type",
         )
         unserialized_data3: OneOfTest.OneOfData1 = s_type_int.unserialize(

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -464,7 +464,7 @@ class OneOfTest(unittest.TestCase):
     discriminator_field_name = "type_"
 
     def setUp(self):
-        self.obj_b: schema.ObjectType = schema.ObjectType(
+        self.obj_b = schema.ObjectType(
             OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())}
         )
         self.scope_basic = schema.ScopeType(

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -463,12 +463,13 @@ class OneOfTest(unittest.TestCase):
 
     def setUp(self):
         self.obj_b: schema.ObjectType = schema.ObjectType(
-            OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())})
+            OneOfTest.OneOfData2, {"b": PropertyType(schema.IntType())}
+        )
         self.scope_basic: schema.ScopeType = schema.ScopeType(
             {
                 "a": schema.ObjectType(
                     OneOfTest.OneOfData1,
-                    {"a": PropertyType(schema.StringType())}
+                    {"a": PropertyType(schema.StringType())},
                 ),
                 "b": self.obj_b,
             },
@@ -492,21 +493,30 @@ class OneOfTest(unittest.TestCase):
 
     def test_assignment(self):
         s_type = schema.OneOfStringType(
-            {"a": schema.RefType("a", self.scope_basic), "b": schema.RefType("b", self.scope_basic)},
+            {
+                "a": schema.RefType("a", self.scope_basic),
+                "b": schema.RefType("b", self.scope_basic),
+            },
             scope=self.scope_basic,
             discriminator_field_name="_type",
         )
         s_type.discriminator_field_name = "foo"
         self.assertEqual("foo", s_type.discriminator_field_name)
         schema.OneOfIntType(
-            {1: schema.RefType(1, self.scope_basic), 2: schema.RefType(2, self.scope_basic)},
+            {
+                1: schema.RefType(1, self.scope_basic),
+                2: schema.RefType(2, self.scope_basic),
+            },
             scope=self.scope_basic,
             discriminator_field_name="_type",
         )
 
     def test_unserialize(self):
         s_type = schema.OneOfStringType(
-            {"a": schema.RefType("a", self.scope_basic), "b": schema.RefType("b", self.scope_basic)},
+            {
+                "a": schema.RefType("a", self.scope_basic),
+                "b": schema.RefType("b", self.scope_basic),
+            },
             scope=self.scope_basic,
             discriminator_field_name="_type",
         )
@@ -537,7 +547,10 @@ class OneOfTest(unittest.TestCase):
 
     def test_unserialize_embedded(self):
         s = schema.OneOfStringType(
-            {"a": schema.RefType("a", self.scope_embedded), "b": schema.RefType("b", self.scope_embedded)},
+            {
+                "a": schema.RefType("a", self.scope_embedded),
+                "b": schema.RefType("b", self.scope_embedded),
+            },
             scope=self.scope_embedded,
             discriminator_field_name="type",
         )
@@ -549,13 +562,18 @@ class OneOfTest(unittest.TestCase):
         self.assertEqual(unserialized_data.type, "a")
         self.assertEqual(unserialized_data.a, "Hello world!")
 
-        unserialized_data2: OneOfTest.OneOfData2 = s.unserialize({"type": "b", "b": 42})
+        unserialized_data2: OneOfTest.OneOfData2 = s.unserialize(
+            {"type": "b", "b": 42}
+        )
         self.assertIsInstance(unserialized_data2, OneOfTest.OneOfData2)
         self.assertEqual(unserialized_data2.b, 42)
 
     def test_validation(self):
         s = schema.OneOfStringType[OneOfTest.OneOfDataEmbedded1](
-            {"a": schema.RefType("a", self.scope_embedded), "b": schema.RefType("b", self.scope_embedded)},
+            {
+                "a": schema.RefType("a", self.scope_embedded),
+                "b": schema.RefType("b", self.scope_embedded),
+            },
             scope=self.scope_embedded,
             discriminator_field_name="type",
         )
@@ -571,7 +589,10 @@ class OneOfTest(unittest.TestCase):
 
     def test_serialize(self):
         s = schema.OneOfStringType(
-            {"a": schema.RefType("a", self.scope_embedded), "b": schema.RefType("b", self.scope_embedded)},
+            {
+                "a": schema.RefType("a", self.scope_embedded),
+                "b": schema.RefType("b", self.scope_embedded),
+            },
             scope=self.scope_embedded,
             discriminator_field_name="type",
         )
@@ -579,7 +600,9 @@ class OneOfTest(unittest.TestCase):
             s.serialize(OneOfTest.OneOfDataEmbedded1("a", "Hello world!")),
             {"type": "a", "a": "Hello world!"},
         )
-        self.assertEqual(s.serialize(OneOfTest.OneOfData2(42)), {"type": "b", "b": 42})
+        self.assertEqual(
+            s.serialize(OneOfTest.OneOfData2(42)), {"type": "b", "b": 42}
+        )
 
     def test_object(self):
         scope = schema.ScopeType({}, "")

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -464,12 +464,9 @@ class OneOfTest(unittest.TestCase):
     # default discriminator field name
     discriminator_default = "_type"
 
-    # When a discriminator is embedded with the data schema of the
-    # OneOfType's constituent types (the types in the union set),
-    # then the constituent type's attribute's identifier must match
-    # the OneOf's discriminator identifier. In this case, the string
-    # "type_" is the discriminator identifier that will be embedded in
-    # OneOfDataEmbedded1.
+    # The string "type_" is the discriminator identifier that will
+    # be embedded in OneOfDataEmbedded1. It must match the OneOfType's
+    # discriminator field name.
     discriminator_field_name = "type_"
 
     def setUp(self):


### PR DESCRIPTION
## Changes introduced with this PR

In anticipation of adding the `discriminator_inlined` attribute to OneOf's, this pull request refactors the minimum code in `OneOfTest` that is expected to be reused across the new unit tests in the anticipated pull request. There are still some remaining spots where code could be deduplicated, but I only wanted to dry out the parts I was most confident that I would reuse.

- [X] Factor out function specific classes
- [X] Reduce duplicate code in `OneOfTest` 
- [X] Add tests for uncovered error cases
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).