### PR TITLE
Hide OneOfSchema Attributes 

### DIFF
--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2614,9 +2614,6 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             "Name of the field used to discriminate between possible values."
         ),
     ] = "_type"
-    myoneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = (
-        None
-    )
 
     def schema_metadata(self) -> OneOfTypeMetadata:
         raise NotImplementedError(

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2598,10 +2598,6 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             " objects' schema"
         ),
     ]
-    # oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
-    # discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
-    #     None
-    # )
     discriminator_field_name: typing.Annotated[
         str,
         _name("Discriminator field name"),

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2525,8 +2525,10 @@ class ObjectSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     id_unenforced: typing.Annotated[
         typing.Optional[bool],
         _name("ID Unenforced"),
-        _description("If true, the ID does not need to match another object "
-                     "for them to be considered compatible."),
+        _description(
+            "If true, the ID does not need to match another object "
+            "for them to be considered compatible."
+        ),
     ] = None
 
     def _to_jsonschema_fragment(
@@ -2590,6 +2592,7 @@ class OneOfTypeMetadata:
         None
     )
 
+
 @dataclass
 class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     types: typing.Union[
@@ -2611,10 +2614,14 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             "Name of the field used to discriminate between possible values."
         ),
     ] = "_type"
-    myoneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
+    myoneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = (
+        None
+    )
 
     def schema_metadata(self) -> OneOfTypeMetadata:
-        raise NotImplementedError("schema_metadata() is not implemented in the subclass")
+        raise NotImplementedError(
+            "schema_metadata() is not implemented in the subclass"
+        )
 
     def _insert_discriminator(
         self,
@@ -6814,9 +6821,8 @@ class _SchemaBuilder:
         # Note: This is an unstable API.
         # noinspection PyProtectedMember
         resolved = t._evaluate(
-            globalns=None,
-            localns=None,
-            recursive_guard=frozenset())
+            globalns=None, localns=None, recursive_guard=frozenset()
+        )
         return cls._resolve(resolved, resolved, path, scope)
 
     @classmethod

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2611,7 +2611,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     ] = "_type"
 
     def schema_metadata(self) -> OneOfTypeMetadata:
-        raise NotImplementedError("schema_metadata() is not implemented in the parent class")
+        raise NotImplementedError("schema_metadata() is not implemented in the subclass")
 
     def _insert_discriminator(
         self,

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2578,6 +2578,13 @@ class ObjectSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
 
 
 @dataclass
+class OneOfTypeMetadata:
+    oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
+    discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
+        None
+    )
+
+@dataclass
 class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     types: typing.Union[
         Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]],
@@ -2591,10 +2598,10 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             " objects' schema"
         ),
     ]
-    oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
-    _discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
-        None
-    )
+    # oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
+    # discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
+    #     None
+    # )
     discriminator_field_name: typing.Annotated[
         str,
         _name("Discriminator field name"),
@@ -2602,6 +2609,19 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             "Name of the field used to discriminate between possible values."
         ),
     ] = "_type"
+
+    def metadata(self) -> OneOfTypeMetadata:
+        if isinstance(self, OneOfStringType):
+            return OneOfTypeMetadata(
+                oneof_type="_discriminated_string_",
+                discriminator_type="string",
+            )
+        elif isinstance(self, OneOfIntType):
+            return OneOfTypeMetadata(
+                oneof_type="_discriminated_int_",
+                discriminator_type="integer",
+            )
+        return None
 
     def _insert_discriminator(
         self,
@@ -2626,7 +2646,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             discriminated_object["properties"][
                 self.discriminator_field_name
             ] = {
-                "type": self._discriminator_type,
+                "type": self.metadata().discriminator_type,
                 "const": discriminator_val,
             }
             # discriminator field is already present in the required
@@ -2652,7 +2672,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
                     defs.defs[v.id]["title"] = v.display.name
                 if v.display.description is not None:
                     defs.defs[v.id]["description"] = v.display.description
-            name = v.id + self.oneof_type + str(k)
+            name = v.id + self.metadata().oneof_type + str(k)
             defs.defs[name] = defs.defs[v.id]
             one_of.append({"$ref": "#/$defs/" + name})
         return {"oneOf": one_of}
@@ -2665,7 +2685,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         for k, v in self.types.items():
             # noinspection PyProtectedMember
             _ = scope.objects[v.id]._to_openapi_fragment(scope, defs)
-            name = v.id + self.oneof_type + str(k)
+            name = v.id + self.metadata().oneof_type + str(k)
             discriminator_mapping[k] = "#/components/schemas/" + name
             self._insert_discriminator(defs.defs[v.id], str(k))
             if v.display is not None:
@@ -2809,9 +2829,9 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    def __post_init__(self):
-        self.oneof_type = "_discriminated_string_"
-        self._discriminator_type = "string"
+    # def __post_init__(self):
+    #     self.oneof_type = "_discriminated_string_"
+    #     self.discriminator_type = "string"
 
 
 @dataclass
@@ -2922,9 +2942,9 @@ class OneOfIntSchema(OneOfSchema):
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    def __post_init__(self):
-        self.oneof_type = "_discriminated_int_"
-        self._discriminator_type = "integer"
+    # def __post_init__(self):
+    #     self.oneof_type = "_discriminated_int_"
+    #     self.discriminator_type = "integer"
 
 
 @dataclass
@@ -4842,12 +4862,14 @@ class PropertyType(PropertySchema, Generic[PropertyT]):
 ObjectT = TypeVar("ObjectT", bound=object)
 
 def invalid_attr_identifier(name: str) -> bool:
-    return name.startswith("_")
+    # return name.startswith("_")
+    return False
 
 
 def dataclasses_fields(dc) -> typing.Iterator[dataclasses.Field]:
     return [
-        f for f in dataclasses.fields(dc) if not invalid_attr_identifier(f.name)
+        f for f in dataclasses.fields(dc)
+        if not invalid_attr_identifier(f.name)
     ]
 
 def get_type_hints(obj: typing.Any) -> dict[str, typing.Any]:

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2615,10 +2615,22 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         ),
     ] = "_type"
 
-    def schema_metadata(self) -> OneOfTypeMetadata:
+    @property
+    def oneof_type(self) -> str:
         raise NotImplementedError(
-            "schema_metadata() is not implemented in the subclass"
+            "oneof_type() is not implemented in the subclass"
         )
+
+    @property
+    def discriminator_type(self) -> str:
+        raise NotImplementedError(
+            "discriminator_type() is not implemented in the subclass"
+        )
+
+    # def schema_metadata(self) -> OneOfTypeMetadata:
+    #     raise NotImplementedError(
+    #         "schema_metadata() is not implemented in the subclass"
+    #     )
 
     def _insert_discriminator(
         self,
@@ -2643,7 +2655,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             discriminated_object["properties"][
                 self.discriminator_field_name
             ] = {
-                "type": self.schema_metadata().discriminator_type,
+                "type": self.discriminator_type,
                 "const": discriminator_val,
             }
             # discriminator field is already present in the required
@@ -2669,7 +2681,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
                     defs.defs[v.id]["title"] = v.display.name
                 if v.display.description is not None:
                     defs.defs[v.id]["description"] = v.display.description
-            name = v.id + self.schema_metadata().oneof_type + str(k)
+            name = v.id + self.oneof_type + str(k)
             defs.defs[name] = defs.defs[v.id]
             one_of.append({"$ref": "#/$defs/" + name})
         return {"oneOf": one_of}
@@ -2682,7 +2694,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         for k, v in self.types.items():
             # noinspection PyProtectedMember
             _ = scope.objects[v.id]._to_openapi_fragment(scope, defs)
-            name = v.id + self.schema_metadata().oneof_type + str(k)
+            name = v.id + self.oneof_type + str(k)
             discriminator_mapping[k] = "#/components/schemas/" + name
             self._insert_discriminator(defs.defs[v.id], str(k))
             if v.display is not None:
@@ -2826,11 +2838,19 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    def schema_metadata(self) -> OneOfTypeMetadata:
-        return OneOfTypeMetadata(
-            oneof_type="_discriminated_string_",
-            discriminator_type="string",
-        )
+    # def schema_metadata(self) -> OneOfTypeMetadata:
+    #     return OneOfTypeMetadata(
+    #         oneof_type="_discriminated_string_",
+    #         discriminator_type="string",
+    #     )
+
+    @property
+    def oneof_type(self) -> str:
+        return "_discriminated_string_"
+
+    @property
+    def discriminator_type(self) -> str:
+        return "string"
 
 
 @dataclass
@@ -2941,11 +2961,18 @@ class OneOfIntSchema(OneOfSchema):
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    def schema_metadata(self) -> OneOfTypeMetadata:
-        return OneOfTypeMetadata(
-            oneof_type="_discriminated_int_",
-            discriminator_type="integer",
-        )
+    # def schema_metadata(self) -> OneOfTypeMetadata:
+    #     return OneOfTypeMetadata(
+    #         oneof_type="_discriminated_int_",
+    #         discriminator_type="integer",
+    #     )
+    @property
+    def oneof_type(self) -> str:
+        return "_discriminated_int_"
+
+    @property
+    def discriminator_type(self) -> str:
+        return "integer"
 
 
 @dataclass

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2611,18 +2611,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     ] = "_type"
 
     def schema_metadata(self) -> OneOfTypeMetadata:
-        # if isinstance(self, OneOfStringType):
-        #     return OneOfTypeMetadata(
-        #         oneof_type="_discriminated_string_",
-        #         discriminator_type="string",
-        #     )
-        # elif isinstance(self, OneOfIntType):
-        #     return OneOfTypeMetadata(
-        #         oneof_type="_discriminated_int_",
-        #         discriminator_type="integer",
-        #     )
-        # return None
-        raise NotImplementedError("Method not implemented in parent class")
+        raise NotImplementedError("schema_metadata() is not implemented in the parent class")
 
     def _insert_discriminator(
         self,
@@ -2830,9 +2819,6 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    # def __post_init__(self):
-    #     self.oneof_type = "_discriminated_string_"
-    #     self.discriminator_type = "string"
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(
             oneof_type="_discriminated_string_",
@@ -2947,10 +2933,6 @@ class OneOfIntSchema(OneOfSchema):
     """  # noqa: E501
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
-
-    # def __post_init__(self):
-    #     self.oneof_type = "_discriminated_int_"
-    #     self.discriminator_type = "integer"
 
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(
@@ -4873,23 +4855,6 @@ class PropertyType(PropertySchema, Generic[PropertyT]):
 
 ObjectT = TypeVar("ObjectT", bound=object)
 
-def invalid_attr_identifier(name: str) -> bool:
-    # return name.startswith("_")
-    return False
-
-
-def dataclasses_fields(dc) -> typing.Iterator[dataclasses.Field]:
-    return [
-        f for f in dataclasses.fields(dc)
-        if not invalid_attr_identifier(f.name)
-    ]
-
-def get_type_hints(obj: typing.Any) -> dict[str, typing.Any]:
-    return {
-        k: v for k, v in typing.get_type_hints(obj).items()
-        if not invalid_attr_identifier(k)
-    }
-
 
 @dataclass
 class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
@@ -4966,16 +4931,15 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
             )
         try:
             # noinspection PyDataclass
-            # dataclasses.fields(cls_type)
-            dataclasses_fields(cls_type)
+            dataclasses.fields(cls_type)
         except Exception as e:
             raise BadArgumentException(
                 "The passed class '{}' is not a dataclass. Please use a"
                 " dataclass.".format(cls_type.__name__)
             ) from e
 
-        class_type_hints = get_type_hints(cls_type)
-        init_type_hints = get_type_hints(cls_type.__init__)
+        class_type_hints = typing.get_type_hints(cls_type)
+        init_type_hints = typing.get_type_hints(cls_type.__init__)
         if (
             len(init_type_hints) == len(properties) + 1
             and "return" in init_type_hints
@@ -5068,7 +5032,7 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
         try:
             class_type_hints = {}
             if hasattr(cls_type, "__dict__"):
-                class_type_hints = get_type_hints(cls_type)
+                class_type_hints = typing.get_type_hints(cls_type)
             if hasattr(cls_type, "__bases__"):
                 for base in cls_type.__bases__:
                     base_class_type_hints = cls._resolve_class_type_hints(
@@ -6539,8 +6503,7 @@ class _SchemaBuilder:
         final_fields: Dict[str, PropertyType] = {}
 
         try:
-            # fields_list = dataclasses.fields(t)
-            fields_list = dataclasses_fields(t)
+            fields_list = dataclasses.fields(t)
         except TypeError as e:
             unsupported_types = {
                 tuple: "tuples",
@@ -6582,7 +6545,7 @@ class _SchemaBuilder:
         # noinspection PyTypeChecker
         scope.objects[t.__name__] = None
 
-        type_hints = get_type_hints(t)
+        type_hints = typing.get_type_hints(t)
         for f in fields_list:
             new_path = list(path)
             new_path.append(f.name)

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2605,6 +2605,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             "Name of the field used to discriminate between possible values."
         ),
     ] = "_type"
+    myoneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
 
     def schema_metadata(self) -> OneOfTypeMetadata:
         raise NotImplementedError("schema_metadata() is not implemented in the subclass")
@@ -2815,6 +2816,9 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
+    def __post_init__(self):
+        self.myoneof_type = "my_oneof_string"
+
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(
             oneof_type="_discriminated_string_",
@@ -2929,6 +2933,9 @@ class OneOfIntSchema(OneOfSchema):
     """  # noqa: E501
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
+
+    def __post_init__(self):
+        self.myoneof_type = "my_oneof_int"
 
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2610,18 +2610,19 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         ),
     ] = "_type"
 
-    def metadata(self) -> OneOfTypeMetadata:
-        if isinstance(self, OneOfStringType):
-            return OneOfTypeMetadata(
-                oneof_type="_discriminated_string_",
-                discriminator_type="string",
-            )
-        elif isinstance(self, OneOfIntType):
-            return OneOfTypeMetadata(
-                oneof_type="_discriminated_int_",
-                discriminator_type="integer",
-            )
-        return None
+    def schema_metadata(self) -> OneOfTypeMetadata:
+        # if isinstance(self, OneOfStringType):
+        #     return OneOfTypeMetadata(
+        #         oneof_type="_discriminated_string_",
+        #         discriminator_type="string",
+        #     )
+        # elif isinstance(self, OneOfIntType):
+        #     return OneOfTypeMetadata(
+        #         oneof_type="_discriminated_int_",
+        #         discriminator_type="integer",
+        #     )
+        # return None
+        raise NotImplementedError("Method not implemented in parent class")
 
     def _insert_discriminator(
         self,
@@ -2646,7 +2647,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             discriminated_object["properties"][
                 self.discriminator_field_name
             ] = {
-                "type": self.metadata().discriminator_type,
+                "type": self.schema_metadata().discriminator_type,
                 "const": discriminator_val,
             }
             # discriminator field is already present in the required
@@ -2672,7 +2673,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
                     defs.defs[v.id]["title"] = v.display.name
                 if v.display.description is not None:
                     defs.defs[v.id]["description"] = v.display.description
-            name = v.id + self.metadata().oneof_type + str(k)
+            name = v.id + self.schema_metadata().oneof_type + str(k)
             defs.defs[name] = defs.defs[v.id]
             one_of.append({"$ref": "#/$defs/" + name})
         return {"oneOf": one_of}
@@ -2685,7 +2686,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         for k, v in self.types.items():
             # noinspection PyProtectedMember
             _ = scope.objects[v.id]._to_openapi_fragment(scope, defs)
-            name = v.id + self.metadata().oneof_type + str(k)
+            name = v.id + self.schema_metadata().oneof_type + str(k)
             discriminator_mapping[k] = "#/components/schemas/" + name
             self._insert_discriminator(defs.defs[v.id], str(k))
             if v.display is not None:
@@ -2832,6 +2833,11 @@ class OneOfStringSchema(OneOfSchema):
     # def __post_init__(self):
     #     self.oneof_type = "_discriminated_string_"
     #     self.discriminator_type = "string"
+    def schema_metadata(self) -> OneOfTypeMetadata:
+        return OneOfTypeMetadata(
+            oneof_type="_discriminated_string_",
+            discriminator_type="string",
+        )
 
 
 @dataclass
@@ -2945,6 +2951,12 @@ class OneOfIntSchema(OneOfSchema):
     # def __post_init__(self):
     #     self.oneof_type = "_discriminated_int_"
     #     self.discriminator_type = "integer"
+
+    def schema_metadata(self) -> OneOfTypeMetadata:
+        return OneOfTypeMetadata(
+            oneof_type="_discriminated_int_",
+            discriminator_type="integer",
+        )
 
 
 @dataclass

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2586,14 +2586,6 @@ class ObjectSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
 
 
 @dataclass
-class OneOfTypeMetadata:
-    oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
-    discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
-        None
-    )
-
-
-@dataclass
 class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
     types: typing.Union[
         Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]],
@@ -2617,20 +2609,21 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
 
     @property
     def oneof_type(self) -> str:
+        """This internal state is implemented as a property because ALL of this
+        class's attributes (public and hidden) are used to define the
+        specification of this Arcaflow type."""
         raise NotImplementedError(
             "oneof_type() is not implemented in the subclass"
         )
 
     @property
     def discriminator_type(self) -> str:
+        """This internal state is implemented as a property because ALL of this
+        class's attributes (public and hidden) are used to define the
+        specification of this Arcaflow type."""
         raise NotImplementedError(
             "discriminator_type() is not implemented in the subclass"
         )
-
-    # def schema_metadata(self) -> OneOfTypeMetadata:
-    #     raise NotImplementedError(
-    #         "schema_metadata() is not implemented in the subclass"
-    #     )
 
     def _insert_discriminator(
         self,
@@ -2838,12 +2831,6 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    # def schema_metadata(self) -> OneOfTypeMetadata:
-    #     return OneOfTypeMetadata(
-    #         oneof_type="_discriminated_string_",
-    #         discriminator_type="string",
-    #     )
-
     @property
     def oneof_type(self) -> str:
         return "_discriminated_string_"
@@ -2961,11 +2948,6 @@ class OneOfIntSchema(OneOfSchema):
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    # def schema_metadata(self) -> OneOfTypeMetadata:
-    #     return OneOfTypeMetadata(
-    #         oneof_type="_discriminated_int_",
-    #         discriminator_type="integer",
-    #     )
     @property
     def oneof_type(self) -> str:
         return "_discriminated_int_"

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -4851,12 +4851,6 @@ def dataclasses_fields(dc) -> typing.Iterator[dataclasses.Field]:
     ]
 
 def get_type_hints(obj: typing.Any) -> dict[str, typing.Any]:
-    # hints = typing.get_type_hints(obj)
-    # publicHints = {}
-    # for key, val in hints.items():
-    #     if not invalid_attr_identifier(key):
-    #         publicHints[key] = val
-    # return publicHints
     return {
         k: v for k, v in typing.get_type_hints(obj).items()
         if not invalid_attr_identifier(k)

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2592,7 +2592,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
         ),
     ]
     oneof_type: typing.Annotated[str, _name("One Of Type Schema Name")] = None
-    discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
+    _discriminator_type: typing.Annotated[str, _name("Discriminator Type")] = (
         None
     )
     discriminator_field_name: typing.Annotated[
@@ -2626,7 +2626,7 @@ class OneOfSchema(_JSONSchemaGenerator, _OpenAPIGenerator):
             discriminated_object["properties"][
                 self.discriminator_field_name
             ] = {
-                "type": self.discriminator_type,
+                "type": self._discriminator_type,
                 "const": discriminator_val,
             }
             # discriminator field is already present in the required
@@ -2811,7 +2811,7 @@ class OneOfStringSchema(OneOfSchema):
 
     def __post_init__(self):
         self.oneof_type = "_discriminated_string_"
-        self.discriminator_type = "string"
+        self._discriminator_type = "string"
 
 
 @dataclass
@@ -2924,7 +2924,7 @@ class OneOfIntSchema(OneOfSchema):
 
     def __post_init__(self):
         self.oneof_type = "_discriminated_int_"
-        self.discriminator_type = "integer"
+        self._discriminator_type = "integer"
 
 
 @dataclass
@@ -4841,6 +4841,27 @@ class PropertyType(PropertySchema, Generic[PropertyT]):
 
 ObjectT = TypeVar("ObjectT", bound=object)
 
+def invalid_attr_identifier(name: str) -> bool:
+    return name.startswith("_")
+
+
+def dataclasses_fields(dc) -> typing.Iterator[dataclasses.Field]:
+    return [
+        f for f in dataclasses.fields(dc) if not invalid_attr_identifier(f.name)
+    ]
+
+def get_type_hints(obj: typing.Any) -> dict[str, typing.Any]:
+    # hints = typing.get_type_hints(obj)
+    # publicHints = {}
+    # for key, val in hints.items():
+    #     if not invalid_attr_identifier(key):
+    #         publicHints[key] = val
+    # return publicHints
+    return {
+        k: v for k, v in typing.get_type_hints(obj).items()
+        if not invalid_attr_identifier(k)
+    }
+
 
 @dataclass
 class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
@@ -4917,15 +4938,16 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
             )
         try:
             # noinspection PyDataclass
-            dataclasses.fields(cls_type)
+            # dataclasses.fields(cls_type)
+            dataclasses_fields(cls_type)
         except Exception as e:
             raise BadArgumentException(
                 "The passed class '{}' is not a dataclass. Please use a"
                 " dataclass.".format(cls_type.__name__)
             ) from e
 
-        class_type_hints = typing.get_type_hints(cls_type)
-        init_type_hints = typing.get_type_hints(cls_type.__init__)
+        class_type_hints = get_type_hints(cls_type)
+        init_type_hints = get_type_hints(cls_type.__init__)
         if (
             len(init_type_hints) == len(properties) + 1
             and "return" in init_type_hints
@@ -5018,7 +5040,7 @@ class ObjectType(ObjectSchema, AbstractType, Generic[ObjectT]):
         try:
             class_type_hints = {}
             if hasattr(cls_type, "__dict__"):
-                class_type_hints = typing.get_type_hints(cls_type)
+                class_type_hints = get_type_hints(cls_type)
             if hasattr(cls_type, "__bases__"):
                 for base in cls_type.__bases__:
                     base_class_type_hints = cls._resolve_class_type_hints(
@@ -6489,7 +6511,8 @@ class _SchemaBuilder:
         final_fields: Dict[str, PropertyType] = {}
 
         try:
-            fields_list = dataclasses.fields(t)
+            # fields_list = dataclasses.fields(t)
+            fields_list = dataclasses_fields(t)
         except TypeError as e:
             unsupported_types = {
                 tuple: "tuples",
@@ -6531,7 +6554,7 @@ class _SchemaBuilder:
         # noinspection PyTypeChecker
         scope.objects[t.__name__] = None
 
-        type_hints = typing.get_type_hints(t)
+        type_hints = get_type_hints(t)
         for f in fields_list:
             new_path = list(path)
             new_path.append(f.name)

--- a/src/arcaflow_plugin_sdk/schema.py
+++ b/src/arcaflow_plugin_sdk/schema.py
@@ -2816,9 +2816,6 @@ class OneOfStringSchema(OneOfSchema):
 
     types: Dict[str, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
 
-    def __post_init__(self):
-        self.myoneof_type = "my_oneof_string"
-
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(
             oneof_type="_discriminated_string_",
@@ -2933,9 +2930,6 @@ class OneOfIntSchema(OneOfSchema):
     """  # noqa: E501
 
     types: Dict[int, typing.Annotated[_OBJECT_LIKE, discriminator("type_id")]]
-
-    def __post_init__(self):
-        self.myoneof_type = "my_oneof_int"
 
     def schema_metadata(self) -> OneOfTypeMetadata:
         return OneOfTypeMetadata(

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -2381,9 +2381,11 @@ class TestStepSchema(unittest.TestCase):
         step_schemaType = plugin.build_schema(stdout_test_step)
         step_schema_serialized = schema.SCHEMA_SCHEMA.serialize(step_schemaType)
         step_schema_unserialized = schema.SCHEMA_SCHEMA.unserialize(step_schema_serialized)
-        self.assertEqual(step_schemaType, step_schema_unserialized)
-        self.assertDictEqual(step_schemaType, step_schema_unserialized)
-        # print(yaml.dump(step_schema_serialized))
+        step_schemaType_serialized = schema.SCHEMA_SCHEMA.serialize(step_schema_unserialized)
+        schema.SCHEMA_SCHEMA.unserialize(step_schemaType_serialized)
+        # self.assertEqual(step_schemaType, step_schema_unserialized)
+        # self.assertDictEqual(step_schemaType, step_schema_unserialized)
+        print(yaml.dump(step_schema_serialized))
         # pprint(schema.SCHEMA_SCHEMA.serialize(step_))
 #
 #     def test_step_type(self):

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -2363,7 +2363,7 @@ class EmptyTestOutput:
     {"success": EmptyTestOutput},
 )
 def stdout_test_step(
-    _: BasicUnion,
+    _: InlineUnion,
 ) -> typing.Tuple[str, EmptyTestOutput]:
     print("Hello world!")
     return "success", EmptyTestOutput()

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -15,7 +15,6 @@ from arcaflow_plugin_sdk.schema import (
     SchemaBuildException, step_object_constructor_param,
 )
 
-
 # default discriminator field name used by the OneOfType
 # when no discriminator field name is declared
 default_discriminator = "_type"
@@ -521,12 +520,6 @@ class ObjectTest(unittest.TestCase):
 
 class OneOfTest(unittest.TestCase):
     def setUp(self):
-        # self.obj_oneof_str = schema.ObjectSchema(
-        #     {
-        #         'oneof': schema.PropertyType()
-        #     },
-        #     root='basic'
-        # )
         self.obj_basic = schema.ObjectType(
             Basic,
             {"msg": PropertyType(schema.StringType())},
@@ -2004,7 +1997,6 @@ class JSONSchemaTest(unittest.TestCase):
                 },
             ),
         }
-
 
         defs = schema._JSONSchemaDefs()
         json_schema = scope._to_jsonschema_fragment(scope, defs)

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -12,7 +12,7 @@ from arcaflow_plugin_sdk.schema import (
     BadArgumentException,
     ConstraintException,
     PropertyType,
-    SchemaBuildException, step_object_constructor_param,
+    SchemaBuildException,
 )
 
 # default discriminator field name used by the OneOfType

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -6,14 +6,17 @@ import typing
 import unittest
 from dataclasses import dataclass
 from re import Pattern
+import yaml
 
 from arcaflow_plugin_sdk import schema
 from arcaflow_plugin_sdk.schema import (
     BadArgumentException,
     ConstraintException,
     PropertyType,
-    SchemaBuildException,
+    SchemaBuildException, step_object_constructor_param,
 )
+
+from pprint import pprint
 
 # default discriminator field name used by the OneOfType
 # when no discriminator field name is declared
@@ -520,6 +523,12 @@ class ObjectTest(unittest.TestCase):
 
 class OneOfTest(unittest.TestCase):
     def setUp(self):
+        # self.obj_oneof_str = schema.ObjectSchema(
+        #     {
+        #         'oneof': schema.PropertyType()
+        #     },
+        #     root='basic'
+        # )
         self.obj_basic = schema.ObjectType(
             Basic,
             {"msg": PropertyType(schema.StringType())},
@@ -892,6 +901,44 @@ class OneOfTest(unittest.TestCase):
             f"Invalid type: '{InlineStr.__name__}'",
             str(cm.exception),
         )
+
+    def test_serialize_scope(self):
+        s = schema.OneOfStringType(
+            {
+                "a": schema.RefType("a", self.scope_basic),
+                "b": schema.RefType("b", self.scope_basic),
+            },
+            scope=self.scope_basic,
+            discriminator_field_name=discriminator_field_name,
+        )
+        s.__name__ = "test_oneofstring"
+        # print(s.__name__)
+        s2 = schema.build_object_schema(s)
+        print(s2)
+        # scope = schema.ScopeType(
+        #     {
+        #         "BasicUnion": schema.ObjectType(
+        #             schema.OneOfStringType,
+        #             {
+        #             # "a": schema.PropertyType(schema.RefType("a", self.scope_basic)),
+        #             # "b": schema.PropertyType(schema.RefType("b", self.scope_basic)),
+        #             "types": schema.PropertyType(
+        #                 schema.MapType(keys=schema.StringType, values=schema._OBJECT_LIKE),
+        #             ),
+        #             #     {
+        #             #     "a": schema.RefType("a", self.scope_basic),
+        #             #     "b": schema.RefType("b", self.scope_basic),
+        #             # },
+        #             #     "scope": schema.PropertyType(schema.ScopeType),
+        #                 "discriminator_inlined": schema.PropertyType(schema.BoolType),
+        #                 "discriminator_field_name": schema.StringType,
+        #         })
+        #     },
+        #     root="BasicUnion"
+        # )
+        # print(scope.serialize(BasicUnion(Basic(msg='hello world'))))
+
+        # print(self.scope_basic.serialize(BasicUnion(Basic(msg='hello world'))))
 
     def test_serialize_inline(self):
         s = schema.OneOfStringType(
@@ -1998,8 +2045,10 @@ class JSONSchemaTest(unittest.TestCase):
             ),
         }
 
+
         defs = schema._JSONSchemaDefs()
         json_schema = scope._to_jsonschema_fragment(scope, defs)
+        pprint(json_schema)
         self.assertEqual(
             {
                 "$defs": {
@@ -2332,6 +2381,108 @@ def load_tests(loader, tests, ignore):
     """This function adds the doctests to the discovery process."""
     tests.addTests(doctest.DocTestSuite(schema))
     return tests
+
+from arcaflow_plugin_sdk import plugin
+#
+# # @dataclasses.dataclass
+# # class EmptyTestInput:
+# #     pass
+#
+#
+@dataclasses.dataclass
+class EmptyTestOutput:
+    pass
+
+
+@plugin.step(
+    "stdout-test",
+    "Stdout test",
+    "A test for writing to stdout.",
+    {"success": EmptyTestOutput},
+)
+def stdout_test_step(
+    _: BasicUnion,
+) -> typing.Tuple[str, EmptyTestOutput]:
+    print("Hello world!")
+    return "success", EmptyTestOutput()
+
+class TestStepSchema(unittest.TestCase):
+    def test_build_schema_step(self):
+        # pprint(scope.objects['BasicUnion'].properties)
+        # for k, v in scope.objects['BasicUnion'].properties.items():
+        #     print(f'k: {k}, v: {v}')
+        # scope = schema.build_object_schema(BasicUnion)
+        # bu = BasicUnion(Basic(msg='hello world'))
+        # print(yaml.dump(scope.serialize(bu)))
+        # pprint(scope.serialize(bu))
+
+        step_ = plugin.build_schema(stdout_test_step)
+        print(yaml.dump(schema.SCHEMA_SCHEMA.serialize(step_)))
+        # pprint(schema.SCHEMA_SCHEMA.serialize(step_))
+#
+#     def test_step_type(self):
+#         scope = schema.ScopeType(
+#             {},
+#             BasicUnion.__name__,
+#         )
+#         scope.objects = {
+#             BasicUnion.__name__: schema.ObjectType(
+#                 BasicUnion,
+#                 {
+#                     "union_basic": schema.PropertyType(
+#                         schema.OneOfStringType(
+#                             {
+#                                 "a": schema.RefType(Basic.__name__, scope),
+#                                 "b": schema.RefType(Basic2.__name__, scope),
+#                             },
+#                             scope,
+#                             discriminator_inlined=False,
+#                         )
+#                     )
+#                 },
+#             ),
+#             Basic.__name__: schema.ObjectType(
+#                 Basic, {"msg": schema.PropertyType(schema.StringType())}
+#             ),
+#             Basic2.__name__: schema.ObjectType(
+#                 Basic2, {"msg2": schema.PropertyType(schema.StringType())}
+#             ),
+#         }
+#         outputScope = schema.ScopeType(
+#             {'EmptyTestOutput': schema.ObjectType(EmptyTestOutput, properties={})},
+#             root='EmptyTestOutput',
+#         )
+#         stepOutput = schema.StepOutputType(outputScope)
+#         step_t = schema.StepType(
+#             id="test_step_type",
+#             input=scope,
+#             outputs={'stdout-test': stepOutput},
+#             signal_handler_method_names=[],
+#             handler=stdout_test_step,
+#             step_object_constructor=None,
+#         )
+#         schema_type = schema.SchemaType({'first': step_t})
+#         # pprint(schema.SCHEMA_SCHEMA.serialize(schema_type))
+#         # pprint(schema_type)
+#
+#         scopedStep = schema.ScopeType(
+#             {
+#                 'step_0': schema.ObjectType(
+#                     schema.StepType,
+#                     properties={
+#                         # 'step_0p': schema.PropertyType(step_t)
+#                         'id': schema.PropertyType(schema.StringType()),
+#                         'input': schema.PropertyType(schema.ScopeType({}, root='')),
+#                         'outputs': schema.PropertyType(schema.MapType(keys=schema.StringType(), values=schema.ScopeType({}, root=''))),
+#                         'handler': schema.PropertyType(schema.Callable),
+#                         'step_object_constructor': schema.PropertyType(schema.MapType(keys=schema.StringType(), values=schema.ScopeType({}, root='')),)
+#                     }
+#
+#                 )
+#             },
+#             root='step_0',
+#         )
+#         pprint(scopedStep.to_jsonschema())
 
 
 if __name__ == "__main__":

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -6,7 +6,6 @@ import typing
 import unittest
 from dataclasses import dataclass
 from re import Pattern
-import yaml
 
 from arcaflow_plugin_sdk import schema
 from arcaflow_plugin_sdk.schema import (
@@ -16,7 +15,6 @@ from arcaflow_plugin_sdk.schema import (
     SchemaBuildException, step_object_constructor_param,
 )
 
-from pprint import pprint
 
 # default discriminator field name used by the OneOfType
 # when no discriminator field name is declared
@@ -2010,7 +2008,6 @@ class JSONSchemaTest(unittest.TestCase):
 
         defs = schema._JSONSchemaDefs()
         json_schema = scope._to_jsonschema_fragment(scope, defs)
-        pprint(json_schema)
         self.assertEqual(
             {
                 "$defs": {
@@ -2343,114 +2340,6 @@ def load_tests(loader, tests, ignore):
     """This function adds the doctests to the discovery process."""
     tests.addTests(doctest.DocTestSuite(schema))
     return tests
-
-from arcaflow_plugin_sdk import plugin
-#
-# # @dataclasses.dataclass
-# # class EmptyTestInput:
-# #     pass
-#
-#
-@dataclasses.dataclass
-class EmptyTestOutput:
-    pass
-
-
-@plugin.step(
-    "stdout-test",
-    "Stdout test",
-    "A test for writing to stdout.",
-    {"success": EmptyTestOutput},
-)
-def stdout_test_step(
-    _: InlineUnion,
-) -> typing.Tuple[str, EmptyTestOutput]:
-    print("Hello world!")
-    return "success", EmptyTestOutput()
-
-class TestStepSchema(unittest.TestCase):
-    def test_build_schema_step(self):
-        # pprint(scope.objects['BasicUnion'].properties)
-        # for k, v in scope.objects['BasicUnion'].properties.items():
-        #     print(f'k: {k}, v: {v}')
-        # scope = schema.build_object_schema(BasicUnion)
-        # bu = BasicUnion(Basic(msg='hello world'))
-        # print(yaml.dump(scope.serialize(bu)))
-        # pprint(scope.serialize(bu))
-
-        step_schemaType = plugin.build_schema(stdout_test_step)
-        step_schema_serialized = schema.SCHEMA_SCHEMA.serialize(step_schemaType)
-        step_schema_unserialized = schema.SCHEMA_SCHEMA.unserialize(step_schema_serialized)
-        step_schemaType_serialized = schema.SCHEMA_SCHEMA.serialize(step_schema_unserialized)
-        schema.SCHEMA_SCHEMA.unserialize(step_schemaType_serialized)
-        # self.assertEqual(step_schemaType, step_schema_unserialized)
-        # self.assertDictEqual(step_schemaType, step_schema_unserialized)
-        print(yaml.dump(step_schema_serialized))
-        # pprint(schema.SCHEMA_SCHEMA.serialize(step_))
-#
-#     def test_step_type(self):
-#         scope = schema.ScopeType(
-#             {},
-#             BasicUnion.__name__,
-#         )
-#         scope.objects = {
-#             BasicUnion.__name__: schema.ObjectType(
-#                 BasicUnion,
-#                 {
-#                     "union_basic": schema.PropertyType(
-#                         schema.OneOfStringType(
-#                             {
-#                                 "a": schema.RefType(Basic.__name__, scope),
-#                                 "b": schema.RefType(Basic2.__name__, scope),
-#                             },
-#                             scope,
-#                             discriminator_inlined=False,
-#                         )
-#                     )
-#                 },
-#             ),
-#             Basic.__name__: schema.ObjectType(
-#                 Basic, {"msg": schema.PropertyType(schema.StringType())}
-#             ),
-#             Basic2.__name__: schema.ObjectType(
-#                 Basic2, {"msg2": schema.PropertyType(schema.StringType())}
-#             ),
-#         }
-#         outputScope = schema.ScopeType(
-#             {'EmptyTestOutput': schema.ObjectType(EmptyTestOutput, properties={})},
-#             root='EmptyTestOutput',
-#         )
-#         stepOutput = schema.StepOutputType(outputScope)
-#         step_t = schema.StepType(
-#             id="test_step_type",
-#             input=scope,
-#             outputs={'stdout-test': stepOutput},
-#             signal_handler_method_names=[],
-#             handler=stdout_test_step,
-#             step_object_constructor=None,
-#         )
-#         schema_type = schema.SchemaType({'first': step_t})
-#         # pprint(schema.SCHEMA_SCHEMA.serialize(schema_type))
-#         # pprint(schema_type)
-#
-#         scopedStep = schema.ScopeType(
-#             {
-#                 'step_0': schema.ObjectType(
-#                     schema.StepType,
-#                     properties={
-#                         # 'step_0p': schema.PropertyType(step_t)
-#                         'id': schema.PropertyType(schema.StringType()),
-#                         'input': schema.PropertyType(schema.ScopeType({}, root='')),
-#                         'outputs': schema.PropertyType(schema.MapType(keys=schema.StringType(), values=schema.ScopeType({}, root=''))),
-#                         'handler': schema.PropertyType(schema.Callable),
-#                         'step_object_constructor': schema.PropertyType(schema.MapType(keys=schema.StringType(), values=schema.ScopeType({}, root='')),)
-#                     }
-#
-#                 )
-#             },
-#             root='step_0',
-#         )
-#         pprint(scopedStep.to_jsonschema())
 
 
 if __name__ == "__main__":

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -2381,9 +2381,7 @@ class TestStepSchema(unittest.TestCase):
         step_schemaType = plugin.build_schema(stdout_test_step)
         step_schema_serialized = schema.SCHEMA_SCHEMA.serialize(step_schemaType)
         step_schema_unserialized = schema.SCHEMA_SCHEMA.unserialize(step_schema_serialized)
-        # self.assertEqual(step_schema, step_schema_unserialized)
-        # out = step_schema_serialized == step_schema_unserialized
-        # self.assertTrue(out)
+        self.assertEqual(step_schemaType, step_schema_unserialized)
         self.assertDictEqual(step_schemaType, step_schema_unserialized)
         # print(yaml.dump(step_schema_serialized))
         # pprint(schema.SCHEMA_SCHEMA.serialize(step_))

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -2378,8 +2378,14 @@ class TestStepSchema(unittest.TestCase):
         # print(yaml.dump(scope.serialize(bu)))
         # pprint(scope.serialize(bu))
 
-        step_ = plugin.build_schema(stdout_test_step)
-        print(yaml.dump(schema.SCHEMA_SCHEMA.serialize(step_)))
+        step_schemaType = plugin.build_schema(stdout_test_step)
+        step_schema_serialized = schema.SCHEMA_SCHEMA.serialize(step_schemaType)
+        step_schema_unserialized = schema.SCHEMA_SCHEMA.unserialize(step_schema_serialized)
+        # self.assertEqual(step_schema, step_schema_unserialized)
+        # out = step_schema_serialized == step_schema_unserialized
+        # self.assertTrue(out)
+        self.assertDictEqual(step_schemaType, step_schema_unserialized)
+        # print(yaml.dump(step_schema_serialized))
         # pprint(schema.SCHEMA_SCHEMA.serialize(step_))
 #
 #     def test_step_type(self):

--- a/src/arcaflow_plugin_sdk/test_schema.py
+++ b/src/arcaflow_plugin_sdk/test_schema.py
@@ -902,44 +902,6 @@ class OneOfTest(unittest.TestCase):
             str(cm.exception),
         )
 
-    def test_serialize_scope(self):
-        s = schema.OneOfStringType(
-            {
-                "a": schema.RefType("a", self.scope_basic),
-                "b": schema.RefType("b", self.scope_basic),
-            },
-            scope=self.scope_basic,
-            discriminator_field_name=discriminator_field_name,
-        )
-        s.__name__ = "test_oneofstring"
-        # print(s.__name__)
-        s2 = schema.build_object_schema(s)
-        print(s2)
-        # scope = schema.ScopeType(
-        #     {
-        #         "BasicUnion": schema.ObjectType(
-        #             schema.OneOfStringType,
-        #             {
-        #             # "a": schema.PropertyType(schema.RefType("a", self.scope_basic)),
-        #             # "b": schema.PropertyType(schema.RefType("b", self.scope_basic)),
-        #             "types": schema.PropertyType(
-        #                 schema.MapType(keys=schema.StringType, values=schema._OBJECT_LIKE),
-        #             ),
-        #             #     {
-        #             #     "a": schema.RefType("a", self.scope_basic),
-        #             #     "b": schema.RefType("b", self.scope_basic),
-        #             # },
-        #             #     "scope": schema.PropertyType(schema.ScopeType),
-        #                 "discriminator_inlined": schema.PropertyType(schema.BoolType),
-        #                 "discriminator_field_name": schema.StringType,
-        #         })
-        #     },
-        #     root="BasicUnion"
-        # )
-        # print(scope.serialize(BasicUnion(Basic(msg='hello world'))))
-
-        # print(self.scope_basic.serialize(BasicUnion(Basic(msg='hello world'))))
-
     def test_serialize_inline(self):
         s = schema.OneOfStringType(
             {


### PR DESCRIPTION
## Changes introduced with this PR

All attributes on the *Schema classes, like `OneOfStringSchema` or `OneOfIntSchema`, in `schema.py` must be public because the schema builder portion of `schema.py` uses metadata analysis of that class's attributes to determine if an instance of the Arcaflow type has been written as specified by the Arcaflow type system (implemented by the *Schema classes and a few other parts of this code base). As a language feature of Python, classes do not have private/hidden attributes. If a private attribute must exist on a *Schema class, then one solution is to encapsulate the required behavior or state on a part of the class that is not used as a part of the metadata analysis. In this pull request I have encapsulated the state we would like to be hidden within method calls on the relevant classes.

Testing for this behavior is not simple, and will have to be introduced in a follow-up pull request.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).